### PR TITLE
feat: add express backend scaffold

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.0.0",
+    "jsonwebtoken": "^9.0.0",
+    "nodemailer": "^6.9.0",
+    "zod": "^3.20.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.11.9",
+    "@types/express": "^4.17.15",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.0"
+  }
+}

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+const messageSchema = z.object({ message: z.string() });
+
+describe('Zod validation', () => {
+  it('validates a correct message', () => {
+    const data = { message: 'hello' };
+    expect(messageSchema.parse(data)).toEqual(data);
+  });
+
+  it('throws on invalid message', () => {
+    expect(() => messageSchema.parse({})).toThrow();
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+import nodemailer from 'nodemailer';
+import { z } from 'zod';
+
+const app = express();
+app.use(express.json());
+
+// MongoDB connection
+const mongoUri = process.env.MONGO_URI || '';
+mongoose
+  .connect(mongoUri)
+  .then(() => console.log('Connected to MongoDB'))
+  .catch((err) => console.error('MongoDB connection error:', err));
+
+// JWT authentication middleware
+const authenticate: express.RequestHandler = (req, res, next) => {
+  const header = req.headers['authorization'];
+  if (!header) return res.status(401).send('No token provided');
+  const token = header.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    (req as any).user = decoded;
+    next();
+  } catch (err) {
+    res.status(401).send('Invalid token');
+  }
+};
+
+// Nodemailer transporter
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: parseInt(process.env.SMTP_PORT || '587'),
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+// Example route using Zod validation
+const messageSchema = z.object({ message: z.string() });
+app.post('/message', authenticate, (req, res) => {
+  const result = messageSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json(result.error.flatten());
+  }
+  transporter
+    .sendMail({
+      from: process.env.SMTP_USER,
+      to: process.env.SMTP_USER,
+      subject: 'New Message',
+      text: result.data.message,
+    })
+    .then(() => res.json({ status: 'sent' }))
+    .catch((err) => res.status(500).json({ error: 'email error', details: err }));
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+
+export default app;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- set up TypeScript backend with Express server
- integrate MongoDB connection, JWT auth, Nodemailer, and Zod validation
- configure Jest testing setup

## Testing
- `npm test --prefix backend` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9ec560d8832aa94773cec40c80f2