### PR TITLE
feat: scaffold frontend with Vite React TS and i18n

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="sv">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frontend</title>
+  </head>
+  <body class="antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.17",
+    "@tanstack/react-query": "^5.17.8",
+    "i18next": "^23.7.12",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-i18next": "^13.2.2",
+    "react-router-dom": "^6.22.1"
+  },
+  "devDependencies": {
+    "@headlessui/tailwindcss": "^0.1.6",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,36 @@
+import { Fragment } from 'react'
+import { Listbox } from '@headlessui/react'
+import { useTranslation } from 'react-i18next'
+
+const languages = [
+  { code: 'sv', label: 'Svenska' },
+  { code: 'en', label: 'English' }
+]
+
+export default function LanguageSwitcher() {
+  const { i18n } = useTranslation()
+
+  return (
+    <Listbox value={i18n.language} onChange={(lang) => i18n.changeLanguage(lang)}>
+      <Listbox.Label className="sr-only">Language</Listbox.Label>
+      <div className="relative">
+        <Listbox.Button className="border rounded px-2 py-1" aria-label="Select language">
+          {languages.find(l => l.code === i18n.language)?.label}
+        </Listbox.Button>
+        <Listbox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded bg-white shadow-lg focus:outline-none">
+          {languages.map(lang => (
+            <Listbox.Option key={lang.code} value={lang.code} as={Fragment}>
+              {({ active, selected }) => (
+                <li
+                  className={`cursor-pointer select-none p-2 ${active ? 'bg-blue-100' : ''} ${selected ? 'font-bold' : ''}`}
+                >
+                  {lang.label}
+                </li>
+              )}
+            </Listbox.Option>
+          ))}
+        </Listbox.Options>
+      </div>
+    </Listbox>
+  )
+}

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,0 +1,18 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import sv from './locales/sv/translation.json'
+import en from './locales/en/translation.json'
+
+i18n.use(initReactI18next).init({
+  resources: {
+    sv: { translation: sv },
+    en: { translation: en }
+  },
+  lng: 'sv',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false
+  }
+})
+
+export default i18n

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,0 +1,4 @@
+{
+  "welcome": "Welcome",
+  "click_me": "Click me"
+}

--- a/frontend/src/locales/sv/translation.json
+++ b/frontend/src/locales/sv/translation.json
@@ -1,0 +1,4 @@
+{
+  "welcome": "Välkommen",
+  "click_me": "Klicka mig"
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { RouterProvider, createBrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nextProvider } from 'react-i18next'
+import i18n from './i18n'
+import Home from './pages/Home'
+import './index.css'
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Home />
+  }
+])
+
+const queryClient = new QueryClient()
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <I18nextProvider i18n={i18n}>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </I18nextProvider>
+  </React.StrictMode>
+)

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from 'react-i18next'
+import LanguageSwitcher from '../components/LanguageSwitcher'
+
+export default function Home() {
+  const { t } = useTranslation()
+
+  return (
+    <main className="p-4">
+      <header className="flex justify-end">
+        <LanguageSwitcher />
+      </header>
+      <h1 className="mt-4 text-2xl font-bold">{t('welcome')}</h1>
+      <p className="mt-2">
+        <button className="mt-4 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
+          {t('click_me')}
+        </button>
+      </p>
+    </main>
+  )
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss'
+import headlessui from '@headlessui/tailwindcss'
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: [headlessui]
+} satisfies Config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()]
+})


### PR DESCRIPTION
## Summary
- scaffold frontend with Vite + React + TypeScript
- configure Tailwind CSS, React Router, React Query, Headless UI, and i18next (sv default, en fallback)

## Testing
- `npm install` *(fails: 403 Forbidden - cannot access registry)*
- `npm run build` *(fails: missing dependencies from failed install)*
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_68befe935e18832a97c94c817045dce7