### PR TITLE
Document environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,47 @@
-# General
+# Backend server configuration
+# NODE_ENV specifies the Node environment (e.g., development, production)
 NODE_ENV=development
-PORT=4000
-BASE_URL=http://localhost:4000
+# PORT sets the backend server port (defaults to 3000)
+PORT=3000
+# BASE_URL is the backend's public URL (defaults to http://localhost:3000)
+BASE_URL=http://localhost:3000
+
+# Frontend application
+# FRONTEND_PORT sets the dev server port for the user-facing site (defaults to 5173)
+FRONTEND_PORT=5173
+# FRONTEND_URL is where the frontend is served (defaults to http://localhost:5173)
+FRONTEND_URL=http://localhost:5173
+
+# Admin dashboard
+# ADMIN_PORT sets the dev server port for the admin panel (defaults to 5174)
+ADMIN_PORT=5174
+# ADMIN_URL is where the admin panel is served (defaults to http://localhost:5174)
+ADMIN_URL=http://localhost:5174
 
 # Database
+# MONGO_URI is the MongoDB connection string
 MONGO_URI=mongodb://localhost:27017/asken
 
 # Authentication
+# JWT_SECRET is used to sign authentication tokens
 JWT_SECRET=replace_me
 
 # Email (SMTP for contact & notifications)
+# SMTP_HOST SMTP server hostname
 SMTP_HOST=replace_me
+# SMTP_PORT SMTP server port (defaults to 587)
 SMTP_PORT=587
+# SMTP_USER username for SMTP authentication
 SMTP_USER=replace_me
+# SMTP_PASS password for SMTP authentication
 SMTP_PASS=replace_me
 
 # Contact routing
+# CONTACT_GENERAL address for general contact inquiries
 CONTACT_GENERAL=info@asken.fi
+# CONTACT_ANTIHARASSMENT address for anti-harassment contact
 CONTACT_ANTIHARASSMENT=hello@asken.fi
 
 # HSL Transport
+# HSL_STOPS list of default stops used for HSL queries
 HSL_STOPS=[{"id":"HSL:12345","label":"Arabia / Arcada","max":6}]

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,37 @@
+# Environment Variables
+
+This project uses environment variables to configure the backend API, the
+frontend client and the admin dashboard. Copy `.env.example` to `.env` and
+adjust the values as needed.
+
+## Backend
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `NODE_ENV` | `development` | Node.js runtime environment |
+| `PORT` | `3000` | Port for the backend API |
+| `BASE_URL` | `http://localhost:3000` | Public URL for the backend API |
+| `MONGO_URI` | `mongodb://localhost:27017/asken` | MongoDB connection string |
+| `JWT_SECRET` | `replace_me` | Secret for signing JWT tokens |
+| `SMTP_HOST` | `replace_me` | SMTP server host |
+| `SMTP_PORT` | `587` | SMTP server port |
+| `SMTP_USER` | `replace_me` | SMTP authentication user |
+| `SMTP_PASS` | `replace_me` | SMTP authentication password |
+| `CONTACT_GENERAL` | `info@asken.fi` | Address for general inquiries |
+| `CONTACT_ANTIHARASSMENT` | `hello@asken.fi` | Address for anti-harassment contact |
+| `HSL_STOPS` | `[{"id":"HSL:12345","label":"Arabia / Arcada","max":6}]` | Default HSL stops list |
+
+## Frontend
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `FRONTEND_PORT` | `5173` | Port for the frontend dev server (Vite default) |
+| `FRONTEND_URL` | `http://localhost:5173` | URL where the frontend is served |
+
+## Admin
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `ADMIN_PORT` | `5174` | Port for the admin panel dev server |
+| `ADMIN_URL` | `http://localhost:5174` | URL where the admin panel is served |
+


### PR DESCRIPTION
## Summary
- clarify default URLs/ports for backend, frontend, and admin
- add environment variable reference documentation

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68bf05feb5e8832a8088e34b2971532f