### PR TITLE
feat: enforce JWT secret configuration

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,13 @@ import { z } from 'zod';
 const app = express();
 app.use(express.json());
 
+// Ensure JWT secret is provided
+const jwtSecret = process.env.JWT_SECRET;
+if (!jwtSecret) {
+  console.error('JWT_SECRET environment variable is required');
+  process.exit(1);
+}
+
 // MongoDB connection
 const mongoUri = process.env.MONGO_URI || '';
 mongoose
@@ -20,7 +27,7 @@ const authenticate: express.RequestHandler = (req, res, next) => {
   if (!header) return res.status(401).send('No token provided');
   const token = header.split(' ')[1];
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const decoded = jwt.verify(token, jwtSecret);
     (req as any).user = decoded;
     next();
   } catch (err) {


### PR DESCRIPTION
## Summary
- require `JWT_SECRET` env var at startup and exit if missing
- drop default `'secret'` fallback when verifying JWTs

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf10aab568832a85b45928c089c30a